### PR TITLE
Fix a crash with an upstream change

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ function generateWrappers(Nvim, types, metadata) {
             return param[1];
         });
         var Type, callArgs;
-        if (typeName === 'Vim') {
+        if (typeName === 'Vim' || typeName === 'Ui') {
             Type = Nvim;
             callArgs = args.join(', ');
         } else {


### PR DESCRIPTION
Adds a check from upstream to prevent a startup error that made NyaoVim unusable.
