### PR TITLE
Avoid deprecated API overwrite new API

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,9 @@ function generateWrappers(Nvim, types, metadata) {
         if (typeName !== 'Nvim' && typeName !== 'Ui') {
             method.metadata.parameterTypes.shift();
         }
+        if (func.deprecated_since && Type.prototype.hasOwnProperty(methodName)) {
+            continue;
+        }
         Type.prototype[methodName] = method;
     }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -106,7 +106,7 @@ describe('Nvim', () => {
     });
 
     it('can call APIs while UI attaching', done => {
-        nvim.uiAttach(80, 24, false)
+        nvim.uiAttach(80, 24, {rgb: false})
             .then( nvim.getWindows())
             .then(() => nvim.uiTryResize(160, 48))
             .then(() => nvim.uiDetach())


### PR DESCRIPTION
Neovim have deprecated API,  for example : 
``` yaml
- method: false
  name: nvim_ui_attach
  parameters:
  - [Integer, width]
  - [Integer, height]
  - [Dictionary, options]
  return_type: void
  since: 1
- deprecated_since: 1
  method: false
  name: ui_attach
  parameters:
  - [Integer, width]
  - [Integer, height]
  - [Boolean, enable_rgb]
  return_type: void
  since: 0
```
Current implementation could overwrite the newer API with deprecated ones, like `ui_attach`

<img width="439" alt="screen shot 2016-11-26 at 6 17 18 pm" src="https://cloud.githubusercontent.com/assets/251450/20639779/8d725dd6-b407-11e6-9623-5e24d9bf9f41.png">

