### PR TITLE
getWindows -> listWins in example

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -43,7 +43,7 @@ attach(nvim_proc.stdin, nvim_proc.stdout).then(function(nvim) {
 
   nvim
     .command('vsp')
-    .then(() => nvim.getWindows())
+    .then(() => nvim.listWins())
     .then(windows => {
       console.log(windows.length);  // 2
       console.log(windows[0] instanceof nvim.Window); // true


### PR DESCRIPTION
getWindows got renamed to listWins, which is already correct in the tests but not in the example - this caused some confusion.

Thanks for this nice library! Currently starting to write a ClojureScript wrapper for it.

Christopher